### PR TITLE
Always track executed 'behavior' in history.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,11 @@ An `event` has the following attributes:
 
 An `effect` is an _Object_ that is the _effect_ of dispatching an `event`. It has the following attributes:
 
+  * `became`: _Function_ _(Default: undefined)_ `function (message) {}` If the actor changed its behavior as a result of processing a `message`, the new behavior it became is referenced here.
+  * `behavior`: _Function_ _(Default: undefined)_ `function (message) {}` The behavior that executed to cause this `effect`, if any.
   * `created`: _Array_ An array of created contexts. A context is the execution context of an actor behavior (the value of _this_ when the behavior executes).
   * `event`: _Object_ _(Default: undefined)_ The event that is the cause of this `effect`, if any.
   * `exception`: _Error_ _(Default: undefined)_ If dispatching the `event` caused an exception, that exception is stored here.
-  * `previous`: _Function_ _(Default: undefined)_ `function (message) {}` If the actor changed its behavior as a result of processing a `message`, the previous behavior is referenced here. The new actor behavior is in `event.context.behavior`.
   * `sent`: _Array_ An array of `events` that represent messages sent by the actor as a result of processing a `message`.
 
 **Public API**

--- a/index.js
+++ b/index.js
@@ -125,10 +125,11 @@ module.exports.tracing = function tracing(options) {
         var effect = exports.effect;
         effect.event = event;
         try {
-            var previous = event.context.behavior;
+            var behavior = event.context.behavior;
+            effect.behavior = behavior;
             event.context.behavior(event.message);  // execute actor behavior
-            if (previous !== event.context.behavior) {
-                effect.previous = previous;
+            if (behavior !== event.context.behavior) {
+                effect.became = event.context.behavior;
             }
         } catch (exception) {
             effect.exception = exception;

--- a/test/test.js
+++ b/test/test.js
@@ -93,7 +93,7 @@ test['tracing should not change initial state after dispatching'] = function (te
 };
 
 test['dispatch returns an effect of actor processing the message'] = function (test) {
-    test.expect(8);
+    test.expect(9);
     var tracing = tart.tracing();
 
     var createdBeh = function createdBeh(message) {};
@@ -114,14 +114,15 @@ test['dispatch returns an effect of actor processing the message'] = function (t
     test.equal(effect.sent[0].message, 'foo');
     test.strictEqual(effect.sent[0].cause.message, 'bar');
     test.strictEqual(effect.sent[0].cause.context.self, actor);
-    test.strictEqual(effect.previous, testBeh);
+    test.strictEqual(effect.behavior, testBeh);
+    test.strictEqual(effect.became, becomeBeh);
     test.strictEqual(effect.event.context.behavior, becomeBeh);
     test.ok(!effect.exception);
     test.done();
 };
 
 test['dispatch returns an effect containing exception if actor throws one'] = function (test) {
-    test.expect(1);
+    test.expect(2);
     var tracing = tart.tracing();
 
     var exception;
@@ -135,6 +136,7 @@ test['dispatch returns an effect containing exception if actor throws one'] = fu
     actor('explode');
 
     var effect = tracing.dispatch();
+    test.strictEqual(effect.behavior, crashBeh);
     test.strictEqual(effect.exception, exception);
     test.done();
 };
@@ -149,7 +151,7 @@ test["dispatch returns 'false' if no events to dispatch"] = function (test) {
 };
 
 test['effects of a dispatched event become part of history'] = function (test) {
-    test.expect(11);
+    test.expect(12);
     var tracing = tart.tracing();
 
     var createdBeh = function createdBeh(message) {};
@@ -173,7 +175,8 @@ test['effects of a dispatched event become part of history'] = function (test) {
     test.equal(effect.sent[0].message, 'foo');
     test.strictEqual(effect.sent[0].cause.message, 'bar');
     test.strictEqual(effect.sent[0].cause.context.self, actor);
-    test.strictEqual(effect.previous, testBeh);
+    test.strictEqual(effect.behavior, testBeh);
+    test.strictEqual(effect.became, becomeBeh);
     test.strictEqual(effect.event.context.behavior, becomeBeh);
     test.ok(!effect.exception);
     test.done();


### PR DESCRIPTION
No longer track 'previous'. Instead if "become" happens track the
new behavior in 'effect.became'.
